### PR TITLE
Some more testing and minor refactoring

### DIFF
--- a/daltonapi/api.py
+++ b/daltonapi/api.py
@@ -4,7 +4,7 @@ This is the core module of the Dalton API wrapper, providing the Atom Class,
 which can be used to query the various API endpoints."""
 
 import json
-from typing import List
+from typing import List, Union
 
 import requests
 
@@ -38,14 +38,14 @@ class Atom:
         """Internal function to make a query and return data
 
         Args:
-                endpoint (str): Endpoint of query
-                params (dict): Dictionary of parameters for the query
+            endpoint (str): Endpoint of query
+            params (dict): Dictionary of parameters for the query
 
         Returns:
-                data (dict): Request data
+            data (dict): Request data
 
         Raises:
-                RequestFailedError: API success returned with False - likely invalid endpoint
+            RequestFailedError: API success returned with False - likely invalid endpoint
         """
         if params is None:
             params = {}
@@ -64,13 +64,13 @@ class Atom:
         """Gets an atomic asset by ID
 
         Args:
-                asset_id (str): Asset ID
+            asset_id (str): Asset ID
 
         Raises:
-                AtomicIDError: Raised when an incorrect asset_id is passed
+            AtomicIDError: Raised when an incorrect asset_id is passed
 
         Returns:
-                Asset: Corresponding object
+            Asset: Corresponding object
         """
         if not isinstance(asset_id, str) or not asset_id.isnumeric():
             raise AtomicIDError(asset_id)
@@ -88,17 +88,17 @@ class Atom:
         """Get a list of assets based on critera. Must have at least 1 criteria
 
         Args:
-                owner (str, optional): account name. Defaults to "".
-                collection (str, Collection, optional): collection name. Defaults to "".
-                schema (str, Schema, optional): schema name. Defaults to "".
-                template (str, Template, optional): template ID. Defaults to "".
-                limit (int, optional): maximum number of results to return. Defaults to 100.
+            owner (str, optional): account name. Defaults to "".
+            collection (str, Collection, optional): collection name. Defaults to "".
+            schema (str, Schema, optional): schema name. Defaults to "".
+            template (str, Template, optional): template ID. Defaults to "".
+            limit (int, optional): maximum number of results to return. Defaults to 100.
 
         Raises:
-                NoFiltersError: Raised when no filters are passed
+            NoFiltersError: Raised when no filters are passed
 
         Returns:
-                list[Assets]: List of Asset objects matching the criteria
+            list[Asset]: List of Asset objects matching the criteria
         """
         fields = {
             "owner": self._process_input(owner),
@@ -116,16 +116,20 @@ class Atom:
         data = self._query(f"{self.endpoint}assets", params=fields)
         return [Asset(nft) for nft in data]
 
-    def get_asset_history(self, item: Asset) -> List[Transfer]:
+    def get_asset_history(self, item: Union[Asset, str]) -> List[Transfer]:
         """Fetches transfer history of an asset
 
         Args:
-            item (Asset): An Asset Object
+            item (Union[Asset, str]): An Asset Object or a string with the asset id
 
         Returns:
-            list: List of transfer objects (try acceesing with str(Transfer) for easy formatting)
+            list[Transfer]: List of transfer objects
         """
-        params = {"asset_id": item.get_id()}
+        if isinstance(item, str) and not item.isnumeric():
+            raise AtomicIDError(item)
+        if isinstance(item, Asset):
+            item = item.get_id()
+        params = {"asset_id": item}
         data = self._query(f"{self.endpoint}transfers", params=params)
         data = [Transfer(t) for t in data]
         return data
@@ -134,56 +138,65 @@ class Atom:
         """Gets an atomic collection by ID
 
         Args:
-                collection_id (str): Collection ID
+            collection_id (str): Collection ID
 
         Raises:
-                AtomicIDError: Raised when an incorrect template_id is passed
+            AtomicIDError: Raised when an incorrect template_id is passed
 
         Returns:
-                Template: Corresponding object
+            Template: Corresponding object
         """
         assert isinstance(collection_id, str), "Collection ID should be passed as a str"
-        assert len(collection_id) == 12, "Collection ID must be 12 characters"
         data = self._query(f"{self.endpoint}collections/{collection_id}")
         return Collection(data)
 
-    def get_template(self, collection_id: str, template_id: str) -> Template:
+    def get_template(
+        self, collection_id: Union[Collection, str], template_id: str
+    ) -> Template:
         """Gets an atomic template by ID
 
         Args:
-                collection_id (str): Collection ID
-                template_id (str): Template ID
+            collection_id (Union[Collection, str]): Collection ID
+            template_id (str): Template ID
 
         Raises:
-                AtomicIDError: Raised when an incorrect template_id is passed
+            AtomicIDError: Raised when an incorrect template_id is passed
 
         Returns:
-                Template: Corresponding object
+            Template: Corresponding object
         """
         assert isinstance(template_id, str), "Template ID should be passed as a str"
-        assert isinstance(collection_id, str), "Collection ID should be passed as a str"
-        assert len(collection_id) == 12, "Collection ID must be 12 characters"
+        assert isinstance(
+            collection_id, (str, Collection)
+        ), "Collection ID should be passed as a str or a Collection object"
+        if isinstance(collection_id, Collection):
+            collection_id = collection_id.get_id()
         if not template_id.isnumeric():
             raise AtomicIDError(template_id)
+
         data = self._query(f"{self.endpoint}templates/{collection_id}/{template_id}")
         return Template(data)
 
-    def get_schema(self, collection_id: str, schema_id: str) -> Schema:
+    def get_schema(self, collection_id: Union[Collection, str], schema_id: str) -> Schema:
         """Gets an atomic template by ID
 
         Args:
-                collection_id (str): Collection ID
-                schema_id (str): Template ID
+            collection_id (Union[Collection, str]): Collection ID
+            schema_id (str): Schema ID
 
         Raises:
-                AtomicIDError: Raised when an incorrect schema_id is passed
+            AtomicIDError: Raised when an incorrect schema_id is passed
 
         Returns:
-                Template: Corresponding object
+            Schema: Corresponding object
         """
-        assert isinstance(schema_id, str), "Template ID should be passed as a str"
-        assert isinstance(collection_id, str), "Collection ID should be passed as a str"
-        assert len(collection_id) == 12, "Collection ID must be 12 characters"
+        assert isinstance(schema_id, str), "Schema ID should be passed as a str"
+        assert isinstance(
+            collection_id, (str, Collection)
+        ), "Collection ID should be passed as a str or a Collection object"
+        if isinstance(collection_id, Collection):
+            collection_id = collection_id.get_id()
+
         data = self._query(f"{self.endpoint}schemas/{collection_id}/{schema_id}")
         return Schema(data)
 
@@ -198,17 +211,17 @@ class Atom:
         """Get a list of burned assets based on critera. Must have at least 1 criteria
 
         Args:
-                owner (str, optional): account name. Defaults to "".
-                collection (str, Collection, optional): collection name. Defaults to "".
-                schema (str, Schema, optional): schema name. Defaults to "".
-                template (str, Template, optional): template ID. Defaults to "".
-                limit (int, optional): maximum number of results to return. Defaults to 100.
+            owner (str, optional): account name. Defaults to "".
+            collection (str, Collection, optional): collection name. Defaults to "".
+            schema (str, Schema, optional): schema name. Defaults to "".
+            template (str, Template, optional): template ID. Defaults to "".
+            limit (int, optional): maximum number of results to return. Defaults to 100.
 
         Raises:
-                NoFiltersError: Raised when no filters are passed
+            NoFiltersError: Raised when no filters are passed
 
         Returns:
-                list[Assets]: List of Asset objects matching the criteria
+            list[Assets]: List of Asset objects matching the criteria
         """
         fields = {
             "owner": self._process_input(owner),

--- a/daltonapi/api.py
+++ b/daltonapi/api.py
@@ -281,8 +281,6 @@ class Atom:
         for key in list(fields.keys()):
             if fields[key] == "":
                 del fields[key]
-        if len(fields) == 0:
-            raise NoFiltersError
         fields["limit"] = limit
         data = self._query(f"{self.endpoint}transfers", params=fields)
         return [Transfer(t) for t in data]

--- a/daltonapi/api.py
+++ b/daltonapi/api.py
@@ -4,6 +4,7 @@ This is the core module of the Dalton API wrapper, providing the Atom Class,
 which can be used to query the various API endpoints."""
 
 import json
+from typing import List
 
 import requests
 
@@ -33,7 +34,7 @@ class Atom:
         """
         self.endpoint = endpoint
 
-    def _query(self, endpoint: str, params=None):
+    def _query(self, endpoint: str, params=None) -> dict:
         """Internal function to make a query and return data
 
         Args:
@@ -54,12 +55,12 @@ class Atom:
             return data["data"]
         raise RequestFailedError
 
-    def _process_input(self, field):
+    def _process_input(self, field) -> str:
         if field.__class__.__bases__[0] == AtomicBaseClass:
             field = field.get_id()
         return field
 
-    def get_asset(self, asset_id: str):
+    def get_asset(self, asset_id: str) -> Asset:
         """Gets an atomic asset by ID
 
         Args:
@@ -83,7 +84,7 @@ class Atom:
         schema: Schema = "",
         template: Template = "",
         limit=100,
-    ):
+    ) -> List[Asset]:
         """Get a list of assets based on critera. Must have at least 1 criteria
 
         Args:
@@ -118,7 +119,7 @@ class Atom:
             return built_data
         return []
 
-    def get_asset_history(self, item: Asset):
+    def get_asset_history(self, item: Asset) -> List[Transfer]:
         """Fetches transfer history of an asset
 
         Args:
@@ -132,7 +133,7 @@ class Atom:
         data = [Transfer(t) for t in data]
         return data
 
-    def get_collection(self, collection_id: str):
+    def get_collection(self, collection_id: str) -> Collection:
         """Gets an atomic collection by ID
 
         Args:
@@ -149,7 +150,7 @@ class Atom:
         data = self._query(f"{self.endpoint}collections/{collection_id}")
         return Collection(data)
 
-    def get_template(self, collection_id: str, template_id: str):
+    def get_template(self, collection_id: str, template_id: str) -> Template:
         """Gets an atomic template by ID
 
         Args:
@@ -170,7 +171,7 @@ class Atom:
         data = self._query(f"{self.endpoint}templates/{collection_id}/{template_id}")
         return Template(data)
 
-    def get_schema(self, collection_id: str, schema_id: str):
+    def get_schema(self, collection_id: str, schema_id: str) -> Schema:
         """Gets an atomic template by ID
 
         Args:
@@ -196,7 +197,7 @@ class Atom:
         schema: Schema = "",
         template: Template = "",
         limit=100,
-    ):
+    ) -> List[Asset]:
         """Get a list of burned assets based on critera. Must have at least 1 criteria
 
         Args:
@@ -243,7 +244,7 @@ class Atom:
         schema: Schema = "",
         template: Template = "",
         limit=100,
-    ):
+    ) -> List[Transfer]:
         """Search for transfers fulfilling a criteria
 
         Args:

--- a/daltonapi/api.py
+++ b/daltonapi/api.py
@@ -114,10 +114,7 @@ class Atom:
         fields["limit"] = limit
 
         data = self._query(f"{self.endpoint}assets", params=fields)
-        if len(data):
-            built_data = [Asset(nft) for nft in data]
-            return built_data
-        return []
+        return [Asset(nft) for nft in data]
 
     def get_asset_history(self, item: Asset) -> List[Transfer]:
         """Fetches transfer history of an asset
@@ -228,10 +225,7 @@ class Atom:
         fields["burned"] = True
 
         data = self._query(f"{self.endpoint}/assets", params=fields)
-        if len(data):
-            built_data = [Asset(nft) for nft in data]
-            return built_data
-        return []
+        return [Asset(nft) for nft in data]
 
     # def get_transfer(self):
     #     pass
@@ -278,7 +272,4 @@ class Atom:
             raise NoFiltersError
         fields["limit"] = limit
         data = self._query(f"{self.endpoint}transfers", params=fields)
-        if len(data):
-            built_data = [Transfer(t) for t in data]
-            return built_data
-        return []
+        return [Transfer(t) for t in data]

--- a/daltonapi/api.py
+++ b/daltonapi/api.py
@@ -20,7 +20,6 @@ from .tools.atomic_errors import AtomicIDError, NoFiltersError, RequestFailedErr
 
 
 class Atom:
-
     """API Wrapper Class for AtomicAssets"""
 
     def __init__(self, endpoint="https://wax.api.atomicassets.io/atomicassets/v1/"):
@@ -28,9 +27,6 @@ class Atom:
 
         Args:
             endpoint (str, optional): Sets API endpoint. Defaults to AtomicAssets hosted API.
-
-        Returns:
-            None
         """
         self.endpoint = endpoint
 
@@ -177,7 +173,9 @@ class Atom:
         data = self._query(f"{self.endpoint}templates/{collection_id}/{template_id}")
         return Template(data)
 
-    def get_schema(self, collection_id: Union[Collection, str], schema_id: str) -> Schema:
+    def get_schema(
+        self, collection_id: Union[Collection, str], schema_id: str
+    ) -> Schema:
         """Gets an atomic template by ID
 
         Args:
@@ -221,7 +219,7 @@ class Atom:
             NoFiltersError: Raised when no filters are passed
 
         Returns:
-            list[Assets]: List of Asset objects matching the criteria
+            list[Asset]: List of Asset objects matching the criteria
         """
         fields = {
             "owner": self._process_input(owner),
@@ -266,7 +264,7 @@ class Atom:
             NoFiltersError: Raised when no criteria provided
 
         Returns:
-            list[Transfers]: List of Transfer objects matching the criteria
+            list[Transfer]: List of Transfer objects matching the criteria
         """
         assert (
             sender != "" or recipient != ""

--- a/daltonapi/tools/atomic_classes.py
+++ b/daltonapi/tools/atomic_classes.py
@@ -43,7 +43,6 @@ class AtomicBaseClass:
         """Returns the primary atomic assets identifier of the object
         E.g. For an asset, returns asset id. For a schema, returns schema name
 
-
         Returns:
             str: id
         """

--- a/daltonapi/tools/atomic_classes.py
+++ b/daltonapi/tools/atomic_classes.py
@@ -49,6 +49,9 @@ class AtomicBaseClass:
         """
         return self.key
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.key})"
+
 
 class Asset(AtomicBaseClass):
     """Class for instantizing Atomic Assets"""
@@ -371,7 +374,7 @@ class Transfer(AtomicBaseClass):
         when = datetime.fromtimestamp(float(self._created_at_time) / 1000).isoformat()
         sender = self._sender_name
         recipient = self._recipient_name
-        return  f"{when}: {sender} ---> {recipient} : {self.memo}"
+        return f"{when}: {sender} ---> {recipient} : {self.memo}"
 
 
 class Account:

--- a/daltonapi/tools/atomic_classes.py
+++ b/daltonapi/tools/atomic_classes.py
@@ -49,6 +49,12 @@ class AtomicBaseClass:
         """
         return self.key
 
+    def __eq__(self, other):
+        return self.key == other.key
+
+    def __ne__(self, other):
+        return not self == other
+
     def __repr__(self):
         return f"{self.__class__.__name__}({self.key})"
 

--- a/daltonapi/tools/atomic_classes.py
+++ b/daltonapi/tools/atomic_classes.py
@@ -2,7 +2,7 @@
 
 Classes for instantizing Atomic Asset data structures"""
 
-
+from typing import Dict, List, Tuple
 from datetime import datetime
 from .atomic_errors import NoCollectionImageError
 
@@ -21,14 +21,14 @@ class AtomicBaseClass:
             setattr(self, "_" + key, data)
         self.key = ""
 
-    def _process_data(self, key: str, data: dict):
+    def _process_data(self, key: str, data: dict) -> Tuple[str, "AtomicBaseClass"]:
         """function to intercept and construct classes
 
         Args:
-                key (str): key to the dict
+            key (str): key to the dict
 
         Returns:
-                dict or class object
+            dict or class object
         """
         conversions = {
             "collection": Collection,
@@ -39,13 +39,13 @@ class AtomicBaseClass:
             data = conversions[key](data)
         return (key, data)
 
-    def get_id(self):
+    def get_id(self) -> str:
         """Returns the primary atomic assets identifier of the object
         E.g. For an asset, returns asset id. For a schema, returns schema name
 
 
         Returns:
-                str: id
+            str: id
         """
         return self.key
 
@@ -66,7 +66,7 @@ class Asset(AtomicBaseClass):
         self.key = self._asset_id
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Returns the asset's name
 
         Returns:
@@ -75,7 +75,7 @@ class Asset(AtomicBaseClass):
         return self._data["name"]
 
     @property
-    def owner(self):
+    def owner(self) -> str:
         """Returns the Asset's owner
 
         Returns:
@@ -84,7 +84,7 @@ class Asset(AtomicBaseClass):
         return self._owner
 
     @property
-    def mint(self):
+    def mint(self) -> Tuple[int, int, int]:
         """Method to obtain mint information of the asset
         if max supply (list[2]) returns 0, there is no maximum limit
 
@@ -109,7 +109,7 @@ class Asset(AtomicBaseClass):
         )
 
     @property
-    def image(self):
+    def image(self) -> str:
         """Returns the primary image of the asset
 
         Returns:
@@ -118,7 +118,7 @@ class Asset(AtomicBaseClass):
         return f"https://ipfs.io/ipfs/{self._data['img']}"
 
     @property
-    def all_media(self):
+    def all_media(self) -> Dict[str, str]:
         """Returns a dict of all media properties of the asset
 
         Returns:
@@ -131,7 +131,7 @@ class Asset(AtomicBaseClass):
         }
 
     @property
-    def burned(self):
+    def burned(self) -> Tuple[str, str, str]:
         """Burn information of the asset.
         Returns (None,None,None) if unburned.
 
@@ -141,7 +141,7 @@ class Asset(AtomicBaseClass):
         return (self._burned_at_block, self._burned_at_time, self._burned_by_account)
 
     @property
-    def burnable(self):
+    def burnable(self) -> bool:
         """Is the asset burnable?
 
         Returns:
@@ -150,7 +150,7 @@ class Asset(AtomicBaseClass):
         return self._is_burnable
 
     @property
-    def transferable(self):
+    def transferable(self) -> bool:
         """Is the asset transferable?
 
         Returns:
@@ -159,7 +159,7 @@ class Asset(AtomicBaseClass):
         return self._is_transferable
 
     @property
-    def last_transferred(self):
+    def last_transferred(self) -> Tuple[str, str]:
         """Information about the last transfer of the asset
 
         Returns:
@@ -168,7 +168,7 @@ class Asset(AtomicBaseClass):
         return (self._transferred_at_block, self._transferred_at_time)
 
     @property
-    def last_updated(self):
+    def last_updated(self) -> Tuple[str, str]:
         """Information about the last update to the asset
 
         Returns:
@@ -177,7 +177,7 @@ class Asset(AtomicBaseClass):
         return (self._updated_at_block, self._updated_at_time)
 
     @property
-    def collection(self):
+    def collection(self) -> "Collection":
         """Returns the Asset's collection
 
         Returns:
@@ -186,7 +186,7 @@ class Asset(AtomicBaseClass):
         return self._collection
 
     @property
-    def schema(self):
+    def schema(self) -> "Schema":
         """Returns the Asset's schema
 
         Returns:
@@ -195,7 +195,7 @@ class Asset(AtomicBaseClass):
         return self._schema
 
     @property
-    def template(self):
+    def template(self) -> "Template":
         """Returns the Asset's template
         Returns None if no template
 
@@ -233,7 +233,7 @@ class Collection(AtomicBaseClass):
         self.key = self._collection_name
 
     @property
-    def image(self):
+    def image(self) -> str:
         """Returns the primary image of the collection
 
         Returns:
@@ -270,7 +270,7 @@ class Template(AtomicBaseClass):
         self.key = self._template_id
 
     @property
-    def image(self):
+    def image(self) -> str:
         """Returns the primary image of the asset
 
         Returns:
@@ -279,7 +279,7 @@ class Template(AtomicBaseClass):
         return f"https://ipfs.io/ipfs/{self._immutable_data['img']}"
 
     @property
-    def all_media(self):
+    def all_media(self) -> Dict[str, str]:
         """Returns a dict of all media properties of the asset
 
         Returns:
@@ -292,7 +292,7 @@ class Template(AtomicBaseClass):
         }
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Returns template name
 
         Returns:
@@ -329,7 +329,7 @@ class Transfer(AtomicBaseClass):
         self.key = self._transfer_id
 
     @property
-    def assets(self):
+    def assets(self) -> List["Asset"]:
         """Returns a list of assets transferred in the transfer
 
         Returns:
@@ -338,7 +338,7 @@ class Transfer(AtomicBaseClass):
         return [Asset(nft) for nft in self._assets]
 
     @property
-    def memo(self):
+    def memo(self) -> str:
         """Returns memo of transfer
 
         Returns:
@@ -347,7 +347,7 @@ class Transfer(AtomicBaseClass):
         return self._memo
 
     @property
-    def contract(self):
+    def contract(self) -> str:
         """Returns contract type of transfer
 
         Returns:
@@ -356,7 +356,7 @@ class Transfer(AtomicBaseClass):
         return self._contract
 
     @property
-    def timestamp(self):
+    def timestamp(self) -> int:
         """Returns timestamp of transfer
 
         Returns:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,29 @@
 """Test configuration"""
 import pytest
 from daltonapi.api import Atom
+from daltonapi.tools.atomic_classes import Asset, Collection, Schema, Template
 
 
 @pytest.fixture(scope="session")
 def atom():
     return Atom()
+
+
+@pytest.fixture(scope="session")
+def asset():
+    return Asset(api_data={"asset_id": "1099518029159"})
+
+
+@pytest.fixture(scope="session")
+def collection():
+    return Collection(api_data={"collection_name": "gpk.topps"})
+
+
+@pytest.fixture(scope="session")
+def schema():
+    return Schema(api_data={"schema_name": "series1"})
+
+
+@pytest.fixture(scope="session")
+def template():
+    return Template(api_data={"template_id": "59492"})

--- a/tests/test_atom.py
+++ b/tests/test_atom.py
@@ -1,39 +1,283 @@
 """Tests for the Atom class"""
 import pytest
 from daltonapi.api import Atom
-from daltonapi.tools.atomic_classes import Asset
-from daltonapi.tools.atomic_errors import AtomicIDError, RequestFailedError
+from daltonapi.tools.atomic_classes import Asset, Template, Collection, Schema, Transfer
+from daltonapi.tools.atomic_errors import (
+    AtomicIDError,
+    RequestFailedError,
+    NoFiltersError,
+)
+
+default_endpoint = "https://wax.api.atomicassets.io/atomicassets/v1/"
+account = "atomicmarket"
 
 
 class TestAtom:
     """Tests the Atom class"""
 
-    default_endpoint = "https://wax.api.atomicassets.io/atomicassets/v1/"
-
     def test_init(self):
         atom = Atom()
-        assert atom.endpoint == self.default_endpoint
+        assert atom.endpoint == default_endpoint
 
         atom = Atom("test_endpoint")
         assert atom.endpoint == "test_endpoint"
 
-    def test_get_asset(self, atom: Atom):
-        asset = atom.get_asset("1099518029159")
-        assert isinstance(asset, Asset)
+    class TestAtomGetAsset:
+        def test_get_asset(self, atom: Atom, asset: Asset):
+            result_asset = atom.get_asset(asset.get_id())
+            assert isinstance(result_asset, Asset)
+            assert result_asset == asset
 
-    def test_get_asset_typecheck(self, atom: Atom):
-        with pytest.raises(AtomicIDError):
-            atom.get_asset("")
+        def test_get_asset_param_check(self, atom: Atom):
+            with pytest.raises(AtomicIDError):
+                atom.get_asset("")
 
-        with pytest.raises(AtomicIDError):
-            atom.get_asset("1te2st1")
+            with pytest.raises(AtomicIDError):
+                atom.get_asset("not numeric")
 
-        with pytest.raises(AtomicIDError):
-            atom.get_asset("1.1")
+            with pytest.raises(AtomicIDError):
+                atom.get_asset("1.1")
 
-        with pytest.raises(AtomicIDError):  # maybe this should be supported
-            atom.get_asset(1)
+            with pytest.raises(AtomicIDError):  # maybe this should be supported
+                atom.get_asset(1)
 
-    def test_get_asset_not_found(self, atom: Atom):
-        with pytest.raises(RequestFailedError):
-            atom.get_asset("0")
+        def test_get_asset_not_found(self, atom: Atom):
+            with pytest.raises(RequestFailedError):
+                atom.get_asset("0")
+
+    class TestAtomGetAssets:
+        def test_get_assets_owner(self, atom: Atom):
+            result = atom.get_assets(owner=account, limit=5)
+            assert isinstance(result, list)
+            assert len(result) > 0
+            assert isinstance(result[0], Asset)
+
+        def test_get_assets_collection(self, atom: Atom, collection: Collection):
+            result_class = atom.get_assets(collection=collection, limit=5)
+            assert isinstance(result_class, list)
+            assert len(result_class) > 0
+            assert isinstance(result_class[0], Asset)
+
+            result_str = atom.get_assets(collection=collection.get_id(), limit=5)
+            assert isinstance(result_str, list)
+            assert len(result_str) > 0
+            assert isinstance(result_str[0], Asset)
+
+            assert result_class == result_str
+
+        def test_get_assets_schema(self, atom: Atom, schema: Schema):
+            result_class = atom.get_assets(schema=schema, limit=5)
+            assert isinstance(result_class, list)
+            assert len(result_class) > 0
+            assert isinstance(result_class[0], Asset)
+
+            result_str = atom.get_assets(schema=schema.get_id(), limit=5)
+            assert isinstance(result_str, list)
+            assert len(result_str) > 0
+            assert isinstance(result_str[0], Asset)
+
+            assert result_class == result_str
+
+        def test_get_assets_template(self, atom: Atom, template: Template):
+            result_class = atom.get_assets(template=template, limit=5)
+            assert isinstance(result_class, list)
+            assert len(result_class) > 0
+            assert isinstance(result_class[0], Asset)
+
+            result_str = atom.get_assets(template=template.get_id(), limit=5)
+            assert isinstance(result_str, list)
+            assert len(result_str) > 0
+            assert isinstance(result_str[0], Asset)
+
+            result_int = atom.get_assets(template=int(template.get_id()), limit=5)
+            assert isinstance(result_int, list)
+            assert len(result_int) > 0
+            assert isinstance(result_int[0], Asset)
+
+            assert result_class == result_str == result_int
+
+        def test_get_assets_param_check(self, atom: Atom):
+            with pytest.raises(NoFiltersError):
+                atom.get_assets()
+
+        def test_get_assets_not_found(self, atom: Atom):
+            result = atom.get_assets(owner="/")
+            assert isinstance(result, list)
+            assert len(result) == 0
+
+        def test_get_assets_invalid_request(self, atom: Atom):
+            with pytest.raises(RequestFailedError):
+                atom.get_assets(template="failed")
+
+    class TestAtomGetAssetHistory:
+        def test_get_asset_history(self, atom: Atom, asset: Asset):
+            result_class = atom.get_asset_history(asset)
+            assert isinstance(result_class, list)
+            assert len(result_class) > 0
+            assert isinstance(result_class[0], Transfer)
+
+            result_str = atom.get_asset_history(asset.get_id())
+            assert isinstance(result_str, list)
+            assert len(result_str) > 0
+            assert isinstance(result_str[0], Transfer)
+
+            assert result_class == result_str
+
+        def test_get_asset_param_check(self, atom: Atom):
+            with pytest.raises(AtomicIDError):
+                atom.get_asset_history("fail")
+
+        def test_get_asset_not_found(self, atom: Atom):
+            result = atom.get_asset_history("0")
+            assert isinstance(result, list)
+            assert len(result) == 0
+
+    class TestAtomGetCollection:
+        def test_get_collection(self, atom: Atom, collection: Collection):
+            result_collection = atom.get_collection(collection.get_id())
+            assert isinstance(result_collection, Collection)
+            assert result_collection == collection
+
+        def test_get_collection_param_check(self, atom: Atom):
+            with pytest.raises(AssertionError):
+                atom.get_collection(1)
+
+        def test_get_collection_not_found(self, atom: Atom):
+            with pytest.raises(RequestFailedError):
+                atom.get_collection("not valid id")
+
+    class TestAtomGetTemplate:
+        def test_get_template(self, atom: Atom, collection: Collection, template: Template):
+            result_template_class = atom.get_template(collection, template.get_id())
+            assert isinstance(result_template_class, Template)
+            assert result_template_class == template
+
+            result_template_str = atom.get_template(collection.get_id(), template.get_id())
+            assert isinstance(result_template_str, Template)
+            assert result_template_str == template
+
+            assert result_template_class == result_template_str == template
+
+        def test_get_template_param_check(self, atom: Atom):
+            with pytest.raises(AssertionError):
+                atom.get_template(123, 123)
+
+            with pytest.raises(AtomicIDError):
+                atom.get_template("123", "not numeric")
+
+        def test_get_template_not_found(
+            self, atom: Atom, collection: Collection, template: Template
+        ):
+            with pytest.raises(RequestFailedError):
+                atom.get_template("invalid collection id", "0")
+
+            with pytest.raises(RequestFailedError):
+                atom.get_template("invalid collection id", template.get_id())
+
+            with pytest.raises(RequestFailedError):
+                atom.get_template(collection.get_id(), "0")
+
+    class TestAtomGetSchema:
+        def test_get_schema(self, atom: Atom, collection: Collection, schema: Schema):
+            result_schema_class = atom.get_schema(collection, schema.get_id())
+            assert isinstance(result_schema_class, Schema)
+            assert result_schema_class == schema
+
+            result_schema_str = atom.get_schema(collection.get_id(), schema.get_id())
+            assert isinstance(result_schema_str, Schema)
+            assert result_schema_str == schema
+
+            assert result_schema_class == result_schema_str == schema
+
+        def test_get_schema_param_check(self, atom: Atom):
+            with pytest.raises(AssertionError):
+                atom.get_schema(123, 123)
+
+        def test_get_schema_not_found(self, atom: Atom, collection: Collection, schema: Schema):
+            with pytest.raises(RequestFailedError):
+                atom.get_schema("invalid collection id", "invalid schema id")
+
+            with pytest.raises(RequestFailedError):
+                atom.get_schema("invalid collection id", schema.get_id())
+
+            with pytest.raises(RequestFailedError):
+                atom.get_schema(collection.get_id(), "0")
+
+    class TestAtomGetTransfers:
+        def test_get_transfers_sender(self, atom: Atom):
+            result = atom.get_transfers(sender=account, limit=5)
+            assert isinstance(result, list)
+            assert len(result) > 0
+            assert isinstance(result[0], Transfer)
+
+        def test_get_transfers_recipient(self, atom: Atom):
+            result = atom.get_transfers(recipient=account, limit=5)
+            assert isinstance(result, list)
+            assert len(result) > 0
+            assert isinstance(result[0], Transfer)
+
+        def test_get_transfers_collection(self, atom: Atom, collection: Collection):
+            result_class = atom.get_transfers(sender=account, collection=collection, limit=5)
+            assert isinstance(result_class, list)
+            assert len(result_class) > 0
+            assert isinstance(result_class[0], Transfer)
+
+            result_str = atom.get_transfers(
+                sender=account, collection=collection.get_id(), limit=5
+            )
+            assert isinstance(result_str, list)
+            assert len(result_str) > 0
+            assert isinstance(result_str[0], Transfer)
+
+            assert result_class == result_str
+
+        def test_get_transfers_schema(self, atom: Atom, schema: Schema):
+            result_class = atom.get_transfers(sender=account, schema=schema, limit=5)
+            assert isinstance(result_class, list)
+            assert len(result_class) > 0
+            assert isinstance(result_class[0], Transfer)
+
+            result_str = atom.get_transfers(sender=account, schema=schema.get_id(), limit=5)
+            assert isinstance(result_str, list)
+            assert len(result_str) > 0
+            assert isinstance(result_str[0], Transfer)
+
+            assert result_class == result_str
+
+        def test_get_transfers_template(self, atom: Atom, template: Template):
+            result_class = atom.get_transfers(sender=account, template=template, limit=5)
+            assert isinstance(result_class, list)
+            assert len(result_class) > 0
+            assert isinstance(result_class[0], Transfer)
+
+            result_str = atom.get_transfers(
+                sender=account, template=template.get_id(), limit=5
+            )
+            assert isinstance(result_str, list)
+            assert len(result_str) > 0
+            assert isinstance(result_str[0], Transfer)
+
+            result_int = atom.get_transfers(
+                sender=account, template=int(template.get_id()), limit=5
+            )
+            assert isinstance(result_int, list)
+            assert len(result_int) > 0
+            assert isinstance(result_int[0], Transfer)
+
+            assert result_class == result_str == result_int
+
+        def test_get_transfers_param_check(self, atom: Atom):
+            with pytest.raises(AssertionError):
+                atom.get_transfers()
+
+            with pytest.raises(AssertionError):
+                atom.get_transfers(collection="missing", schema="sender and", template="recipient")
+
+        def test_get_transfers_not_found(self, atom: Atom):
+            result = atom.get_transfers(sender="/", recipient="/")
+            assert isinstance(result, list)
+            assert len(result) == 0
+
+        def test_get_transfers_invalid_request(self, atom: Atom):
+            with pytest.raises(RequestFailedError):
+                atom.get_transfers(sender="/", recipient="/", template="failed")


### PR DESCRIPTION
Changelog:
- added testing for almost all methods of the Atom class
- added __repr__, __eq__ and __ne__ methods to AtomicBaseClass
- minor refactoring
- added typehinting for the return types

Also, I would suggest there changes (not implemented in this pull request):
- _Atom.get_burned(...)_ can be fully integrated in _Atom.get_assets(...)_, with the addition of a _burned_ flag
- You could take a look in the [@dataclass](https://realpython.com/python-data-classes/) decorator, it could be used for the AtomicBaseClass classes
- About the documentation, you could try to add the  'sphinx_autodoc_typehints' extension.
   You would have to run
  ```bash
   pip install sphinx_autodoc_typehints
   ```
  and in the _conf.py_ file:
   ```python
   extensions = [
    "sphinx.ext.autodoc",
    "sphinx.ext.napoleon",
    "sphinx_rtd_theme",
    'sphinx_autodoc_typehints',  # automatic type hinting
   ]
   ```
   Then, in each comment, you can remove the typing. For example:
   ```python
    """Example doc

    Args:
        endpoint (str): Endpoint of query
        params (dict, optional): Dictionary of parameters for the query. Defaults to None

    Returns:
        data (dict): Request data
    """
   ```
   becomes
   ```python
    """Example doc

    Args:
        endpoint: Endpoint of query
        params: Dictionary of parameters for the query. Defaults to None

    Returns:
        data: Request data
    """
   ```
  If you are interested, I have a small [README](https://github.com/TendTo/sphinx-doc/blob/main/README.md) you could read